### PR TITLE
Update dependencies and refactor back press callbacks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "app.marcdev.hibi"
         minSdkVersion 23
         targetSdkVersion 28
-        versionCode 25
-        versionName "1.0.0-pre"
+        versionCode 26
+        versionName "1.0.0-pre2"
         setProperty("archivesBaseName", "Hibi-v$versionName")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -39,7 +39,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1'
 
     // AndroidX
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha02'
+    implementation 'androidx.appcompat:appcompat:1.1.0-beta01'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta1'
     implementation 'androidx.preference:preference:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
@@ -52,8 +52,8 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // Navigation components
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.0.0'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.0.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.1.0-alpha05'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.1.0-alpha05'
 
     // Timber for logging
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/app/src/main/java/app/marcdev/hibi/entryscreens/addentryscreen/AddEntryFragment.kt
+++ b/app/src/main/java/app/marcdev/hibi/entryscreens/addentryscreen/AddEntryFragment.kt
@@ -85,10 +85,12 @@ class AddEntryFragment : Fragment(), KodeinAware {
     bindViews(view)
     initBackConfirmDialog()
     focusInput()
-    requireActivity().addOnBackPressedCallback(this, OnBackPressedCallback {
+    val backPressCallback = object : OnBackPressedCallback(true) {
+      override fun handleOnBackPressed() {
       viewModel.backPress(contentInput.text.toString().isEmpty())
-      true
-    })
+      }
+    }
+    requireActivity().onBackPressedDispatcher.addCallback(this, backPressCallback)
     setupObservers()
     setupImageRecycler(view)
     return view

--- a/app/src/main/java/app/marcdev/hibi/maintabs/mainentriesrecycler/EntriesRecyclerAdapter.kt
+++ b/app/src/main/java/app/marcdev/hibi/maintabs/mainentriesrecycler/EntriesRecyclerAdapter.kt
@@ -7,6 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.RecyclerView
 import app.marcdev.hibi.R
 
@@ -17,6 +19,10 @@ class EntriesRecyclerAdapter(private val context: Context, private val theme: Re
   private var lastPosition = -1
   private var itemsSelectable = false
   private var onSelectClick: View.OnClickListener? = null
+
+  private var _hasSelectedItems = MutableLiveData<Boolean>()
+  val hasSelectedItems: LiveData<Boolean>
+    get() = _hasSelectedItems
 
   constructor(context: Context, itemsSelectable: Boolean, onSelectClick: View.OnClickListener, theme: Resources.Theme) : this(context, theme) {
     this.itemsSelectable = itemsSelectable
@@ -45,6 +51,7 @@ class EntriesRecyclerAdapter(private val context: Context, private val theme: Re
     items.forEach { item ->
       item.isSelected = false
     }
+    _hasSelectedItems.value = false
     notifyDataSetChanged()
   }
 
@@ -71,6 +78,7 @@ class EntriesRecyclerAdapter(private val context: Context, private val theme: Re
       if(!isHeader(position)) {
         holder.itemView.findViewById<ConstraintLayout>(R.id.const_item_main_recycler).setOnLongClickListener {
           items[position].isSelected = !items[position].isSelected
+          _hasSelectedItems.value = getSelectedEntryIds().isNotEmpty()
           notifyItemChanged(position)
           true
         }

--- a/app/src/main/java/app/marcdev/hibi/maintabs/searchentries/searchentriesscreen/SearchEntriesFragment.kt
+++ b/app/src/main/java/app/marcdev/hibi/maintabs/searchentries/searchentriesscreen/SearchEntriesFragment.kt
@@ -85,13 +85,15 @@ class SearchEntriesFragment : Fragment(), KodeinAware {
     setupMainObservers()
     setupBottomSheetObservers()
 
-    requireActivity().addOnBackPressedCallback(this, OnBackPressedCallback {
-      if(criteriaBottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED)
-        criteriaBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
-      else
-        Navigation.findNavController(requireView()).popBackStack()
-      true
-    })
+    val backPressCallback = object : OnBackPressedCallback(true) {
+      override fun handleOnBackPressed() {
+        if(criteriaBottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED)
+          criteriaBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+        else
+          Navigation.findNavController(requireView()).popBackStack()
+      }
+    }
+    requireActivity().onBackPressedDispatcher.addCallback(this, backPressCallback)
 
     return view
   }


### PR DESCRIPTION
New version of the AppCompat and Navigation libraries removed the old way of handling back press callbacks